### PR TITLE
Fix incorrect plural name in /about command output

### DIFF
--- a/ballsdex/packages/info/cog.py
+++ b/ballsdex/packages/info/cog.py
@@ -127,7 +127,7 @@ class Info(commands.Cog):
             f"The bot has been online for **{formatted_uptime}**.\n\n"
             f"**{balls_count:,}** {settings.plural_collectible_name} to collect\n"
             f"**{players_count:,}** players that caught "
-            f"**{balls_instances_count:,}** {settings.plural_collectible_name}\n"
+            f"**{balls_instances_count:,}** {settings.plural_collectible_name[:-1]}\n"
             f"**{len(self.bot.guilds):,}** servers playing\n\n"
             f"{dex_credits}\n\n"
             "Consider supporting El Laggron on "


### PR DESCRIPTION
Fixed a minor typo in /about command, countryballss --> countryballs

### Description of the changes

<!--
Describe the changes you have made in this pull request.

Feel free to include screenshots of the new feature if applicable!

If the changes resolve an issue, please include "Resolves #XX" where "XX" is the issue number.
-->
Fixed a spelling mitake in the /about command. 
![image](https://github.com/user-attachments/assets/f4cf3886-518d-4347-bca3-92b5239416ef)
The second reference to country balls gets an 'S' appended twice so i remove the last character on the second iteration.

### Were the changes in this PR tested?
Unable to access a test environment at the current moment, sorry if this is bad practice.

<!--

If your change is only grammatical and doesn't change any logic, choose "Yes".
-->
Yes

<!--
If the change you introduced is big enough, make a list of checkboxes with all different
cases to test. You can also request additional help for testing thoroughly.
-->